### PR TITLE
[#5] User, Calendar 도메인 엔티티 구현

### DIFF
--- a/src/main/java/com/example/demo/domain/calendar/domain/Calendar.java
+++ b/src/main/java/com/example/demo/domain/calendar/domain/Calendar.java
@@ -1,0 +1,28 @@
+package com.example.demo.domain.calendar.domain;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "calendars")
+public class Calendar {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    @NotBlank(message = "제목은 빈값 일 수 없습니다.")
+    private String title;
+
+    @Column(nullable = false)
+    @NotBlank(message = "내용은 빈값 일 수 없습니다.")
+    private String contents;
+
+    private Date date;
+}

--- a/src/main/java/com/example/demo/domain/calendar/domain/Calendar.java
+++ b/src/main/java/com/example/demo/domain/calendar/domain/Calendar.java
@@ -1,5 +1,6 @@
 package com.example.demo.domain.calendar.domain;
 
+import com.example.demo.domain.user.domain.User;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
@@ -25,4 +26,8 @@ public class Calendar {
     private String contents;
 
     private Date date;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
 }

--- a/src/main/java/com/example/demo/domain/user/domain/User.java
+++ b/src/main/java/com/example/demo/domain/user/domain/User.java
@@ -1,0 +1,56 @@
+package com.example.demo.domain.user.domain;
+
+import com.example.demo.global.base.domain.BaseEntity;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static com.example.demo.global.regex.UserRegex.EMAIL_REGEXP;
+import static com.example.demo.global.regex.UserRegex.NAME_REGEXP;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "users")
+public class User extends BaseEntity {
+    public enum Role {
+        ROLE_USER,
+        ROLE_ADMIN
+    }
+    public enum Track {
+        TRACK_BACK,
+        TRACK_FRONT
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 20)
+    @NotBlank(message = "이름은 빈값 일 수 없습니다.")
+    @Pattern(regexp = NAME_REGEXP, message = "이름 형식이 맞지 않습니다.")
+    private String name;
+
+    @Column(nullable = false, length = 30)
+    @NotBlank(message = "이메일은 빈값 일 수 없습니다.")
+    @Pattern(regexp = EMAIL_REGEXP, message = "이메일 형식이 맞지 않습니다.")
+    private String email;
+
+    @Column(nullable = false)
+    @NotBlank(message = "비밀번호는 빈값 일 수 없습니다.")
+    private String password;
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(nullable = false, length = 10)
+    private Role role;
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(nullable = false, length = 10)
+    private Track track;
+
+    @Column(nullable = false)
+    @NotBlank(message = "전공은 빈값 일 수 없습니다.")
+    private String major;
+}

--- a/src/main/java/com/example/demo/domain/user/domain/User.java
+++ b/src/main/java/com/example/demo/domain/user/domain/User.java
@@ -1,11 +1,14 @@
 package com.example.demo.domain.user.domain;
 
+import com.example.demo.domain.calendar.domain.Calendar;
 import com.example.demo.global.base.domain.BaseEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 import static com.example.demo.global.regex.UserRegex.EMAIL_REGEXP;
 import static com.example.demo.global.regex.UserRegex.NAME_REGEXP;
@@ -53,4 +56,7 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     @NotBlank(message = "전공은 빈값 일 수 없습니다.")
     private String major;
+
+    @OneToMany(mappedBy = "user")
+    private List<Calendar> calendars;
 }

--- a/src/main/java/com/example/demo/global/base/dto/ApiResponse.java
+++ b/src/main/java/com/example/demo/global/base/dto/ApiResponse.java
@@ -1,0 +1,31 @@
+package com.example.demo.global.base.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@JsonPropertyOrder({"success", "data"})
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApiResponse<T> {
+    private final Boolean success;
+    private final T data;
+
+    public static ApiResponse<Void> ok(Boolean success) {
+        return new ApiResponse<>(success, null);
+    }
+
+    public static <T> ApiResponse<T> ok(T data) {
+        return new ApiResponse<>(true, data);
+    }
+
+    public static <T> ApiResponse<T> ok(Boolean success, T data) {
+        return new ApiResponse<>(success, data);
+    }
+
+    public static ApiResponse<Void> noData() {
+        return new ApiResponse<>(true, null);
+    }
+}

--- a/src/main/java/com/example/demo/global/regex/UserRegex.java
+++ b/src/main/java/com/example/demo/global/regex/UserRegex.java
@@ -1,0 +1,12 @@
+package com.example.demo.global.regex;
+
+public class UserRegex {
+    // 2~20, 한글, 영문 대소문자, 숫자, '[]<>-' 기호 허용
+    public static final String NAME_REGEXP = "^[가-힣a-zA-Z\\d\\[\\]<>-]{2,20}";
+
+    // 일반적인 이메일 형식 체크
+    public static final String EMAIL_REGEXP = "[a-z0-9]+@[a-z]+\\.[a-z]{2,8}$";
+
+    // 최소 8, 최대 25자 이내. 적어도 하나의 영문자와 하나의 숫자를 포함해야 한다.
+    public static final String PASSWORD_REGEXP = "^(?=.*[a-zA-Z])(?=.*[0-9]).{8,25}$";
+}


### PR DESCRIPTION
<!-- 제목은 `[#이슈번호] 제목` 으로 작성한다. ex) [#8] 결제 기능 -->

### 🌱 작업 사항 
- User, Calendar 도메인 엔티티 구현

### ❓ 리뷰 포인트
- 다른 엔티티에 대한 연관관계 설정은 추후에 할 예정입니다.
- 테이블 이름은 복수형으로 맞췄습니다.
- Pattern을 사용해서 필드 형식 체크를 추가했습니다.
- 변경할 점이나 이해안가는 부분이 있으면 리뷰로 말씀해주세요.

추가한 점!!
- ApiResponse라는 공통 응답을 정의하는 클래스를 만들었습니다.
  - 모든 응답은 해당 클래스를 거쳐서 만들면 됩니다.
  - 처음 프로젝트 세팅부분에서 넣어야했는데, 살짝 늦어진점 죄송합니다..

### 🦄 관련 이슈
resolves #5
