### PR TITLE
[#10] JWT 설정 & 로그인 기능 구현

### DIFF
--- a/src/docs/asciidoc/Auth.adoc
+++ b/src/docs/asciidoc/Auth.adoc
@@ -137,4 +137,44 @@ include::{snippets}/auth/auth-signup-fail-track-not-found/http-response.adoc[]
 include::{snippets}/auth/auth-signup-fail-track-not-found/response-fields.adoc[]
 .Response Body
 include::{snippets}/auth/auth-signup-fail-track-not-found/response-body.adoc[]
+
+
+== POST: 로그인
+=== 성공
+
+.Request
+include::{snippets}/auth/auth-login-success/http-request.adoc[]
+.Request Fields
+include::{snippets}/auth/auth-login-success/request-fields.adoc[]
+.Request Body
+include::{snippets}/auth/auth-login-success/request-body.adoc[]
+
+.Response
+include::{snippets}/auth/auth-login-success/http-response.adoc[]
+.Response Fields
+include::{snippets}/auth/auth-login-success/response-fields.adoc[]
+.Response Body
+include::{snippets}/auth/auth-login-success/response-body.adoc[]
 ---
+
+=== 실패: 필드값이 부적합 할 경우
+이 경우는 회원가입과 같음.
+
+---
+
+=== 실패: 이메일이 존재하지 않거나, 비밀번호가 틀린 경우
+이메일 존재 여/부 따로, 비밀번호 틀린 경우 따로하면 이메일을 유추가능하기에 예외처리를 같이 함.
+
+.Request
+include::{snippets}/auth/auth-login-fail-wrong-email-or-password/http-request.adoc[]
+.Request Body
+include::{snippets}/auth/auth-login-fail-wrong-email-or-password/request-body.adoc[]
+
+.Response
+include::{snippets}/auth/auth-login-fail-wrong-email-or-password/http-response.adoc[]
+.Response Fields
+include::{snippets}/auth/auth-login-fail-wrong-email-or-password/response-fields.adoc[]
+.Response Body
+include::{snippets}/auth/auth-login-fail-wrong-email-or-password/response-body.adoc[]
+---
+

--- a/src/main/java/com/example/demo/domain/auth/api/AuthController.java
+++ b/src/main/java/com/example/demo/domain/auth/api/AuthController.java
@@ -2,7 +2,9 @@ package com.example.demo.domain.auth.api;
 
 import com.example.demo.domain.auth.application.AuthService;
 import com.example.demo.domain.auth.dto.request.JoinRequest;
+import com.example.demo.domain.auth.dto.request.LoginRequest;
 import com.example.demo.domain.auth.dto.request.ValidateEmailRequest;
+import com.example.demo.domain.auth.dto.response.LoginResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -35,5 +37,12 @@ public class AuthController {
         return ResponseEntity.
                 noContent()
                 .build();
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login(@RequestBody @Valid LoginRequest request) {
+        LoginResponse loginResponse = authService.login(request);
+
+        return ResponseEntity.ok(loginResponse);
     }
 }

--- a/src/main/java/com/example/demo/domain/auth/application/AuthService.java
+++ b/src/main/java/com/example/demo/domain/auth/application/AuthService.java
@@ -1,15 +1,22 @@
 package com.example.demo.domain.auth.application;
 
 import com.example.demo.domain.auth.dto.request.JoinRequest;
+import com.example.demo.domain.auth.dto.request.LoginRequest;
+import com.example.demo.domain.auth.dto.response.LoginResponse;
 import com.example.demo.domain.user.domain.User;
 import com.example.demo.domain.user.repository.UserRepository;
+import com.example.demo.global.auth.token.application.TokenProvider;
 import com.example.demo.global.base.exception.ServiceException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import static com.example.demo.global.base.exception.ErrorCode.EXIST_SAME_EMAIL;
+import static com.example.demo.global.base.exception.ErrorCode.MISMATCH_EMAIL_OR_PASSWORD;
 
 @RequiredArgsConstructor
 @Service
@@ -17,6 +24,8 @@ import static com.example.demo.global.base.exception.ErrorCode.EXIST_SAME_EMAIL;
 public class AuthService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final TokenProvider tokenProvider;
 
     @Transactional
     public void join(JoinRequest request) {
@@ -31,5 +40,21 @@ public class AuthService {
 
     public boolean isNotExistEmail(String email) {
         return !userRepository.existsByEmail(email);
+    }
+
+    public LoginResponse login(LoginRequest request) {
+        UsernamePasswordAuthenticationToken authenticationToken =
+                new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword());
+        try {
+            Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+
+            String accessToken = tokenProvider.createAccessToken(authentication);
+
+            return new LoginResponse(accessToken, "Bearer");
+        } catch (Exception e) {
+            // 이메일 & 비밀번호를 따로 예외처리를 하면 이메일을 유추할 수 있게되기에 공통 처리
+            throw new ServiceException(MISMATCH_EMAIL_OR_PASSWORD);
+        }
+
     }
 }

--- a/src/main/java/com/example/demo/domain/auth/application/CustomUserDetailsService.java
+++ b/src/main/java/com/example/demo/domain/auth/application/CustomUserDetailsService.java
@@ -1,0 +1,27 @@
+package com.example.demo.domain.auth.application;
+
+import com.example.demo.domain.auth.domain.UserPrincipal;
+import com.example.demo.domain.user.repository.UserRepository;
+import com.example.demo.global.base.exception.ErrorCode;
+import com.example.demo.global.base.exception.ServiceException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    public CustomUserDetailsService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        return userRepository.findByEmail(email)
+                .map(UserPrincipal::new)
+                .orElseThrow(() -> new ServiceException(ErrorCode.FAIL_USER_LOGIN));
+    }
+}

--- a/src/main/java/com/example/demo/domain/auth/domain/UserPrincipal.java
+++ b/src/main/java/com/example/demo/domain/auth/domain/UserPrincipal.java
@@ -1,0 +1,65 @@
+package com.example.demo.domain.auth.domain;
+
+import com.example.demo.domain.user.domain.User;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+public class UserPrincipal implements UserDetails {
+
+    private final User user;
+
+    public UserPrincipal(User user) {
+        this.user = user;
+    }
+
+
+    @JsonIgnore
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        GrantedAuthority authority = new SimpleGrantedAuthority(user.getRole().name());
+        return Collections.singleton(authority);
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    public Long getId() {
+        return user.getId();
+    }
+
+    public String getName() {
+        return user.getName();
+    }
+}

--- a/src/main/java/com/example/demo/domain/auth/dto/request/LoginRequest.java
+++ b/src/main/java/com/example/demo/domain/auth/dto/request/LoginRequest.java
@@ -1,0 +1,21 @@
+package com.example.demo.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static com.example.demo.global.regex.UserRegex.EMAIL_REGEXP;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class LoginRequest {
+    @NotBlank(message = "이메일을 입력해주세요.")
+    @Pattern(regexp = EMAIL_REGEXP, message = "이메일 형식이 맞지 않습니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private String password;
+}

--- a/src/main/java/com/example/demo/domain/auth/dto/response/LoginResponse.java
+++ b/src/main/java/com/example/demo/domain/auth/dto/response/LoginResponse.java
@@ -1,0 +1,11 @@
+package com.example.demo.domain.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginResponse {
+    private String accessToken;
+    private String tokenType;
+}

--- a/src/main/java/com/example/demo/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/demo/domain/user/repository/UserRepository.java
@@ -2,9 +2,14 @@ package com.example.demo.domain.user.repository;
 
 import com.example.demo.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByName(String name);
 
     boolean existsByEmail(String email);
+
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/example/demo/global/auth/token/application/TokenProvider.java
+++ b/src/main/java/com/example/demo/global/auth/token/application/TokenProvider.java
@@ -1,0 +1,106 @@
+package com.example.demo.global.auth.token.application;
+
+import com.example.demo.global.auth.token.exception.NotSupportedTokenException;
+import com.example.demo.global.base.exception.ServiceException;
+import io.jsonwebtoken.*;
+
+import com.example.demo.domain.auth.application.CustomUserDetailsService;
+import com.example.demo.global.auth.token.exception.ExpiredTokenException;
+import com.example.demo.global.auth.token.exception.InvalidTokenException;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+import static com.example.demo.global.base.exception.ErrorCode.NOT_AUTHORIZED_TOKEN;
+
+@Component
+public class TokenProvider {
+    private static final long MILLI_SECOND = 1000L;
+    private static final String AUTHORITY = "auth";
+    private final String issuer;
+    private final String secretKey;
+    private final long accessTokenExpirySeconds;
+    private final CustomUserDetailsService userDetailsService;
+
+    public TokenProvider(@Value("${jwt.issuer}") String issuer,
+                         @Value("${jwt.secret-key}") String secretKey,
+                         @Value("${jwt.expiry-seconds.access-token}") long accessTokenExpirySeconds,
+                         CustomUserDetailsService userDetailsService) {
+        this.issuer = issuer;
+        this.secretKey = secretKey;
+        this.accessTokenExpirySeconds = accessTokenExpirySeconds;
+        this.userDetailsService = userDetailsService;
+    }
+
+    public String createAccessToken(Authentication authentication) {
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        return Jwts.builder()
+                .setIssuer(issuer)
+                .setSubject(authentication.getName())
+                .claim(AUTHORITY, authorities)
+                .setExpiration(new Date(System.currentTimeMillis() + accessTokenExpirySeconds*MILLI_SECOND))
+                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8)))
+                .compact();
+    }
+
+    public Authentication getAuthentication(String accessToken) {
+        validateToken(accessToken);
+
+        Claims claims = parseClaims(accessToken);
+
+        if (claims.get("auth") == null) {
+            throw new ServiceException(NOT_AUTHORIZED_TOKEN);
+        }
+
+        Collection<? extends GrantedAuthority> authorities =
+                Arrays.stream(claims.get("auth").toString().split(","))
+                        .map(SimpleGrantedAuthority::new)
+                        .toList();
+
+        String username = claims.getSubject();
+        UserDetails user = userDetailsService.loadUserByUsername(username);
+
+        return new UsernamePasswordAuthenticationToken(user, "", authorities);
+    }
+
+    public void validateToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8)))
+                    .build()
+                    .parseClaimsJws(token);
+        } catch (ExpiredJwtException e) {
+            throw new ExpiredTokenException();
+        } catch (UnsupportedJwtException e) {
+            throw new NotSupportedTokenException();
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new InvalidTokenException();
+        }
+    }
+
+    private Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8)))
+                    .build()
+                    .parseClaimsJws(accessToken)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+}

--- a/src/main/java/com/example/demo/global/auth/token/exception/ExpiredTokenException.java
+++ b/src/main/java/com/example/demo/global/auth/token/exception/ExpiredTokenException.java
@@ -1,0 +1,11 @@
+package com.example.demo.global.auth.token.exception;
+
+import com.example.demo.global.base.exception.ErrorCode;
+
+public class ExpiredTokenException extends TokenException{
+    private static final ErrorCode ERROR_CODE = ErrorCode.EXPIRED_TOKEN;
+
+    public ExpiredTokenException() {
+        super(ERROR_CODE);
+    }
+}

--- a/src/main/java/com/example/demo/global/auth/token/exception/InvalidTokenException.java
+++ b/src/main/java/com/example/demo/global/auth/token/exception/InvalidTokenException.java
@@ -1,0 +1,11 @@
+package com.example.demo.global.auth.token.exception;
+
+import com.example.demo.global.base.exception.ErrorCode;
+
+public class InvalidTokenException extends TokenException{
+    private static final ErrorCode ERROR_CODE = ErrorCode.INVALID_TOKEN;
+
+    public InvalidTokenException() {
+        super(ERROR_CODE);
+    }
+}

--- a/src/main/java/com/example/demo/global/auth/token/exception/NotSupportedTokenException.java
+++ b/src/main/java/com/example/demo/global/auth/token/exception/NotSupportedTokenException.java
@@ -1,0 +1,11 @@
+package com.example.demo.global.auth.token.exception;
+
+import com.example.demo.global.base.exception.ErrorCode;
+
+public class NotSupportedTokenException extends TokenException{
+    private static final ErrorCode ERROR_CODE = ErrorCode.NOT_SUPPORTED_TOKEN;
+
+    public NotSupportedTokenException() {
+        super(ERROR_CODE);
+    }
+}

--- a/src/main/java/com/example/demo/global/auth/token/exception/TokenException.java
+++ b/src/main/java/com/example/demo/global/auth/token/exception/TokenException.java
@@ -1,0 +1,11 @@
+package com.example.demo.global.auth.token.exception;
+
+import com.example.demo.global.base.exception.ErrorCode;
+import com.example.demo.global.base.exception.ServiceException;
+
+public abstract class TokenException extends ServiceException {
+
+    protected TokenException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/demo/global/auth/token/filter/ExceptionHandlerFilter.java
+++ b/src/main/java/com/example/demo/global/auth/token/filter/ExceptionHandlerFilter.java
@@ -1,0 +1,44 @@
+package com.example.demo.global.auth.token.filter;
+
+import com.example.demo.global.base.dto.ErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class ExceptionHandlerFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (JwtException ex) {
+            setErrorResponse(HttpStatus.UNAUTHORIZED, request, response, ex);
+        }
+    }
+
+    public void setErrorResponse(HttpStatus status, HttpServletRequest request,
+                                 HttpServletResponse response, Throwable ex) throws IOException {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        response.setStatus(status.value());
+        response.setContentType("application/json; charset=UTF-8");
+
+        log.error(ex.getMessage());
+
+        response.getWriter().write(objectMapper.writeValueAsString(ErrorResponse.of(status, ex.getMessage())));
+    }
+
+
+}

--- a/src/main/java/com/example/demo/global/auth/token/filter/JwtFilter.java
+++ b/src/main/java/com/example/demo/global/auth/token/filter/JwtFilter.java
@@ -1,0 +1,57 @@
+package com.example.demo.global.auth.token.filter;
+
+import com.example.demo.global.auth.token.application.TokenProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+public class JwtFilter extends OncePerRequestFilter {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final TokenProvider tokenProvider;
+
+    public JwtFilter(TokenProvider tokenProvider) {
+        this.tokenProvider = tokenProvider;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        String token = resolveToken(request);
+
+        if(token != null) {
+            Authentication authentication = tokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(HttpHeaders.AUTHORIZATION);
+        return isBearerToken(bearerToken) ? extractJwt(bearerToken) : null;
+    }
+
+    private boolean isBearerToken(String token) {
+        return token != null && token.startsWith(BEARER_PREFIX);
+    }
+
+    private String extractJwt(String bearerToken) {
+        return bearerToken.substring(BEARER_PREFIX.length());
+    }
+
+//    @Override
+//    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+//        return request.getRequestURI().endsWith();
+//    }
+}

--- a/src/main/java/com/example/demo/global/base/exception/ErrorCode.java
+++ b/src/main/java/com/example/demo/global/base/exception/ErrorCode.java
@@ -20,10 +20,21 @@ public enum ErrorCode {
 
     // 400 error
     INVALID_JSON(HttpStatus.BAD_REQUEST, "JSON 파싱 오류입니다."),
+    MISMATCH_EMAIL_OR_PASSWORD(HttpStatus.BAD_REQUEST, "이메일 혹은 비밀번호가 틀렸습니다."),
+
+    // 401 error
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
+    NOT_SUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "지원하지 않는 토큰입니다."),
+    NOT_AUTHORIZED_TOKEN(HttpStatus.UNAUTHORIZED, "권한 정보가 없는 토큰입니다."),
+
+    // 404 error
+    FAIL_USER_LOGIN(HttpStatus.NOT_FOUND, "존재하지 않는 계정입니다."),
 
     // 409 error
     EXIST_SAME_NAME(HttpStatus.CONFLICT, "이미 사용중인 이름 입니다."),
     EXIST_SAME_EMAIL(HttpStatus.CONFLICT, "이미 사용중인 이메일 입니다."),
+
 
 
 

--- a/src/main/java/com/example/demo/global/config/auth/SecurityConfig.java
+++ b/src/main/java/com/example/demo/global/config/auth/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.example.demo.global.config.auth;
 
+import com.example.demo.global.auth.token.application.TokenProvider;
+import com.example.demo.global.auth.token.filter.JwtFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -8,21 +10,36 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.servlet.util.matcher.MvcRequestMatcher;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
+
+    private final TokenProvider tokenProvider;
+
+    public SecurityConfig(TokenProvider tokenProvider) {
+        this.tokenProvider = tokenProvider;
+    }
+
     @Bean
-    public SecurityFilterChain httpSecurity(HttpSecurity http, HandlerMappingIntrospector introspector) throws Exception {
+    public SecurityFilterChain httpSecurity(HttpSecurity http) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests((authorizeRequests) -> authorizeRequests
-                        .requestMatchers(new MvcRequestMatcher(introspector, "**")).permitAll()
-                        .requestMatchers("/demo").permitAll()
-                        .requestMatchers("/api/auth/**").permitAll());
+                        .requestMatchers(
+                                new AntPathRequestMatcher("/demo"),
+                                new AntPathRequestMatcher("/api/auth/**"),
+                                new AntPathRequestMatcher("/docs/**")
+                        ).permitAll()
+                        .anyRequest().authenticated())
+
+                .addFilterBefore(new JwtFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class)
+        ;
 
 
         return http.build();

--- a/src/main/java/com/example/demo/global/config/web/WebConfig.java
+++ b/src/main/java/com/example/demo/global/config/web/WebConfig.java
@@ -1,21 +1,20 @@
 package com.example.demo.global.config.web;
 
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
+import org.springframework.web.servlet.config.annotation.*;
 
+@EnableWebMvc
 @Configuration
-public class WebConfig extends WebMvcConfigurationSupport {
+public class WebConfig implements WebMvcConfigurer {
     @Override
-    protected void addCorsMappings(CorsRegistry registry) {
+    public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
                 .allowedOriginPatterns("http://localhost:8080/", "/**")
                 .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE")
                 .allowCredentials(true);
     }
     @Override
-    protected void addResourceHandlers(ResourceHandlerRegistry registry) {
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
         registry.addResourceHandler("/docs/**")
                 .addResourceLocations("classpath:/static/docs/");
     }


### PR DESCRIPTION
<!-- 제목은 `[#이슈번호] 제목` 으로 작성한다. ex) [#8] 결제 기능 -->

### 🌱 작업 사항 
- JWT 설정
- 로그인 기능 구현
  - 현재는 AccessToken만 존재
- 로그인 테스트를 통한 API 문서 작성

### ❓ 리뷰 포인트
- 이메일 & 비밀번호 관련 오류 통일 -> "이메일이나 비밀번호가 틀렸습니다."
  1. 따로 처리를 해버리면, 이메일이 유추 가능하기에
  2. `CustomUserDetailsService`의 `loadUserByUsername` 메서드를 통해 이메일 존재 여/부를 검사하는데, 여기서 던진 예외가 500 error로 가서 잡히는 문제 발생
  - 그래서 조금더 공부해보고 나중에 이메일 존재 여/부와 비밀번호 틀릴 때 예외 처리를 리팩토링 할 예정

- 또 바꿨으면 하는 점이나 궁금한 점 있으시면 말씀해주세요!


### 🦄 관련 이슈
resolves #10