### PR TITLE
[#14] 이메일 인증 기능 추가

### DIFF
--- a/.github/workflows/ci-gradle-build.yml
+++ b/.github/workflows/ci-gradle-build.yml
@@ -40,7 +40,12 @@ jobs:
           spring.datasource.url: ${{ secrets.SPRING_DATASOURCE_URL }}
           spring.datasource.username: ${{ secrets.SPRING_DATASOURCE_USERNAME }}
           spring.datasource.password: ${{ secrets.SPRING_DATASOURCE_PASSWORD }}
+          spring.data.redis.host: ${{ secrets.REDIS_HOST }}
+          spring.data.redis.port: ${{ secrets.REDIS_PORT }}
+          spring.mail.username: ${{ secrets.MAIL_USERNAME }}
+          spring.mail.password: ${{ secrets.MAIL_PASSWORD }}
           jwt.secret-key: ${{ secrets.JWT_SECRET_KEY }}
+
 
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,9 +27,11 @@ dependencies {
     // WEB
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-mail:3.0.5'
 
     // DB
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // REST Docs
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'

--- a/src/docs/asciidoc/Auth.adoc
+++ b/src/docs/asciidoc/Auth.adoc
@@ -6,7 +6,7 @@
 :toclevels: 2
 
 [[User-API]]
-== POST: 닉네임 중복 검사
+== POST: 이메일 인증 코드 보내기
 === 성공
 
 .Request
@@ -19,7 +19,7 @@ include::{snippets}/auth/auth-duplicate-email-check-success/request-body.adoc[]
 .Response
 include::{snippets}/auth/auth-duplicate-email-check-success/http-response.adoc[]
 ---
-=== 실패: 이미 존재하는 닉네임
+=== 실패: 이미 존재하는 이메일
 
 .Request
 include::{snippets}/auth/auth-duplicate-email-check-fail-already-exist/http-request.adoc[]
@@ -34,7 +34,7 @@ include::{snippets}/auth/auth-duplicate-email-check-fail-already-exist/response-
 include::{snippets}/auth/auth-duplicate-email-check-fail-already-exist/response-body.adoc[]
 ---
 
-=== 실패: 조건에 맞지 않는 닉네임
+=== 실패: 조건에 맞지 않는 이메일
 
 .Request
 include::{snippets}/auth/auth-duplicate-email-check-fail-not-valid-form/http-request.adoc[]
@@ -137,6 +137,23 @@ include::{snippets}/auth/auth-signup-fail-track-not-found/http-response.adoc[]
 include::{snippets}/auth/auth-signup-fail-track-not-found/response-fields.adoc[]
 .Response Body
 include::{snippets}/auth/auth-signup-fail-track-not-found/response-body.adoc[]
+---
+
+=== 실패: 올바르지 않은 인증코드를 입력한 경우
+
+.Request
+include::{snippets}/auth/auth-signup-fail-authCode-is-not-correct/http-request.adoc[]
+.Request Fields
+include::{snippets}/auth/auth-signup-fail-authCode-is-not-correct/request-fields.adoc[]
+.Request Body
+include::{snippets}/auth/auth-signup-fail-authCode-is-not-correct/request-body.adoc[]
+
+.Response
+include::{snippets}/auth/auth-signup-fail-authCode-is-not-correct/http-response.adoc[]
+.Response Fields
+include::{snippets}/auth/auth-signup-fail-authCode-is-not-correct/response-fields.adoc[]
+.Response Body
+include::{snippets}/auth/auth-signup-fail-authCode-is-not-correct/response-body.adoc[]
 
 
 == POST: 로그인

--- a/src/main/java/com/example/demo/domain/auth/api/AuthController.java
+++ b/src/main/java/com/example/demo/domain/auth/api/AuthController.java
@@ -10,10 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -21,21 +18,21 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
     private final AuthService authService;
 
-    @PostMapping(value = "/sign-up", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<Void> join(@RequestBody @Valid JoinRequest request) {
-        authService.join(request);
+    @PostMapping("/emails/verification-requests")
+    public ResponseEntity<Void> sendMessage(@RequestBody @Valid ValidateEmailRequest request) {
+        authService.sendCodeToEmail(request);
 
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .build();
     }
 
-    @PostMapping("/duplicate")
-    public ResponseEntity<Void> checkEmail(@RequestBody @Valid ValidateEmailRequest request) {
-        boolean notExistEmail = authService.isNotExistEmail(request.getEmail());
+    @PostMapping(value = "/sign-up", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Void> join(@RequestBody @Valid JoinRequest request) {
+        authService.join(request);
 
-        return ResponseEntity.
-                noContent()
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
                 .build();
     }
 

--- a/src/main/java/com/example/demo/domain/auth/dto/request/JoinRequest.java
+++ b/src/main/java/com/example/demo/domain/auth/dto/request/JoinRequest.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -24,6 +25,10 @@ public class JoinRequest {
     @NotBlank(message = "이메일은 빈값 일 수 없습니다.")
     @Pattern(regexp = EMAIL_REGEXP, message = "이메일 형식이 맞지 않습니다.")
     private String email;
+
+    @NotBlank(message = "인증 코드는 빈값 일 수 없습니다.")
+    @Size(min = 6, max = 6, message = "인증 코드는 6자리여야 합니다.")
+    private String authCode;
 
     @NotBlank(message = "비밀번호는 빈값 일 수 없습니다.")
     @Pattern(regexp = PASSWORD_REGEXP, message = "비밀번호 형식이 맞지 않습니다.")

--- a/src/main/java/com/example/demo/global/base/exception/ErrorCode.java
+++ b/src/main/java/com/example/demo/global/base/exception/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
     // 400 error
     INVALID_JSON(HttpStatus.BAD_REQUEST, "JSON 파싱 오류입니다."),
     MISMATCH_EMAIL_OR_PASSWORD(HttpStatus.BAD_REQUEST, "이메일 혹은 비밀번호가 틀렸습니다."),
+    MISMATCH_EMAIL_AUTH_CODE(HttpStatus.BAD_REQUEST, "인증 코드가 틀렸습니다."),
 
     // 401 error
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
@@ -35,8 +36,9 @@ public enum ErrorCode {
     EXIST_SAME_NAME(HttpStatus.CONFLICT, "이미 사용중인 이름 입니다."),
     EXIST_SAME_EMAIL(HttpStatus.CONFLICT, "이미 사용중인 이메일 입니다."),
 
-
-
+    // 500 error
+    UNABLE_TO_SEND_EMAIL(HttpStatus.INTERNAL_SERVER_ERROR, "이메일을 전송할 수 없습니다."),
+    NO_SUCH_ALGORITHM(HttpStatus.INTERNAL_SERVER_ERROR, "해당 알고리즘을 찾을 수 없습니다."),
 
     ;
 

--- a/src/main/java/com/example/demo/global/config/db/JpaConfig.java
+++ b/src/main/java/com/example/demo/global/config/db/JpaConfig.java
@@ -1,4 +1,4 @@
-package com.example.demo.global.config.jpa;
+package com.example.demo.global.config.db;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;

--- a/src/main/java/com/example/demo/global/config/db/RedisConfig.java
+++ b/src/main/java/com/example/demo/global/config/db/RedisConfig.java
@@ -1,0 +1,43 @@
+package com.example.demo.global.config.db;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        // 일반적인 key:value의 경우 시리얼라이저
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        // Hash를 사용할 경우 시리얼라이저
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+
+        // 모든 경우
+        redisTemplate.setDefaultSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/example/demo/global/config/web/email/EmailConfig.java
+++ b/src/main/java/com/example/demo/global/config/web/email/EmailConfig.java
@@ -1,0 +1,67 @@
+package com.example.demo.global.config.web.email;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class EmailConfig {
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Value("${spring.mail.properties.mail.smtp.auth}")
+    private boolean auth;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+    private boolean starttlsEnable;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.required}")
+    private boolean starttlsRequired;
+
+    @Value("${spring.mail.properties.mail.smtp.connectiontimeout}")
+    private int connectionTimeout;
+
+    @Value("${spring.mail.properties.mail.smtp.timeout}")
+    private int timeout;
+
+    @Value("${spring.mail.properties.mail.smtp.writetimeout}")
+    private int writeTimeout;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+        mailSender.setDefaultEncoding("UTF-8");
+        mailSender.setJavaMailProperties(getMailProperties());
+
+        return mailSender;
+    }
+
+    private Properties getMailProperties() {
+        Properties properties = new Properties();
+        properties.put("mail.smtp.auth", auth);
+        properties.put("mail.smtp.starttls.enable", starttlsEnable);
+        properties.put("mail.smtp.starttls.required", starttlsRequired);
+        properties.put("mail.smtp.connectiontimeout", connectionTimeout);
+        properties.put("mail.smtp.timeout", timeout);
+        properties.put("mail.smtp.writetimeout", writeTimeout);
+
+        return properties;
+    }
+}

--- a/src/main/java/com/example/demo/global/regex/UserRegex.java
+++ b/src/main/java/com/example/demo/global/regex/UserRegex.java
@@ -4,8 +4,8 @@ public class UserRegex {
     // 2~20, 한글, 영문 대소문자, 숫자, '[]<>-' 기호 허용
     public static final String NAME_REGEXP = "^[가-힣a-zA-Z\\d\\[\\]<>-]{2,20}";
 
-    // 일반적인 이메일 형식 체크
-    public static final String EMAIL_REGEXP = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,6}$";
+    // kit 학교 이메일 형식 체크
+    public static final String EMAIL_REGEXP = "^[a-zA-Z0-9._%+-]+@kumoh\\.ac\\.kr$";
 
     // 최소 8, 최대 25자 이내. 적어도 하나의 영문자와 하나의 숫자를 포함해야 한다.
     public static final String PASSWORD_REGEXP = "^(?=.*[a-zA-Z])(?=.*[0-9]).{8,25}$";

--- a/src/main/java/com/example/demo/global/utils/RedisUtils.java
+++ b/src/main/java/com/example/demo/global/utils/RedisUtils.java
@@ -1,0 +1,37 @@
+package com.example.demo.global.utils;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+@RequiredArgsConstructor
+@Component
+public class RedisUtils {
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public void setData(String key, String value, Duration expiredTime) {
+        redisTemplate.opsForValue().set(key, value, expiredTime);
+    }
+
+    @Transactional(readOnly = true)
+    public String getValues(String key) {
+        ValueOperations<String, Object> values = redisTemplate.opsForValue();
+        if (values.get(key) == null) {
+            return "false";
+        }
+        return (String) values.get(key);
+    }
+
+    public void deleteData(String key) {
+        redisTemplate.delete(key);
+    }
+
+    public boolean checkExistsValue(String value) {
+        return !value.equals("false");
+    }
+}

--- a/src/main/resources/application-db.yml
+++ b/src/main/resources/application-db.yml
@@ -22,5 +22,8 @@ spring:
         jdbc:
           time-zone: Asia/Seoul
         format_sql: true
-
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
 

--- a/src/main/resources/application-mail.yml
+++ b/src/main/resources/application-mail.yml
@@ -1,0 +1,17 @@
+spring:
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000
+    auth-code-expiration-millis: 180000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,3 +8,4 @@ spring:
     include:
       - db
       - security
+      - mail

--- a/src/test/java/com/example/demo/domain/auth/api/AuthControllerTest.java
+++ b/src/test/java/com/example/demo/domain/auth/api/AuthControllerTest.java
@@ -38,35 +38,33 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class AuthControllerTest extends ControllerTest {
 
     @Nested
-    @DisplayName("<이메일 중복검사>")
+    @DisplayName("<이메일 인증코드 보내기>")
     class emailDuplicateTest {
 
-        String duplicateApi = "/api/auth/duplicate";
+        String sendAuthCodeApi = "/api/auth/emails/verification-requests";
 
-        @DisplayName("중복 이메일이 없다면 성공")
-        @ValueSource(strings = {"test@test.com", "teat@test.com", "test@naver.com", "test@kumoh.ac.kr"})
+        @DisplayName("중복 이메일이 없고, 형식에 맞다면 성공")
+        @ValueSource(strings = {"eee@kumoh.ac.kr", "teat@kumoh.ac.kr", "abc@kumoh.ac.kr", "test@kumoh.ac.kr"})
         @ParameterizedTest
         void successIfNoDuplicateEmail(String email) throws Exception {
             // given
-            ValidateEmailRequest request = new ValidateEmailRequest(email);
-
-            when(authService.isNotExistEmail(email)).thenReturn(true);
+            ValidateEmailRequest request = new ValidateEmailRequest(email);;
 
             // when -> then
-            mockMvc.perform(post(duplicateApi)
+            mockMvc.perform(post(sendAuthCodeApi)
                     .with(user("user").roles("USER"))
                     .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request))
                     )
-                    .andExpect(status().isNoContent())
+                    .andExpect(status().isCreated())
                     .andDo(print())
                     .andDo(document(
                             "auth/auth-duplicate-email-check-success",
                             preprocessRequest(prettyPrint()),
                             requestFields(
                                     fieldWithPath("email").type(JsonFieldType.STRING)
-                                            .description("중복 검사 대상 이메일")
+                                            .description("인증 코드를 받을 이메일")
                             )
                     ));
         }
@@ -78,10 +76,10 @@ public class AuthControllerTest extends ControllerTest {
             ValidateEmailRequest request = new ValidateEmailRequest("test@kumoh.ac.kr");
             ServiceException serviceException = new ServiceException(ErrorCode.EXIST_SAME_EMAIL);
 
-            doThrow(serviceException).when(authService).isNotExistEmail(request.getEmail());
+            doThrow(serviceException).when(authService).sendCodeToEmail(any(ValidateEmailRequest.class));
 
             // when -> then
-            mockMvc.perform(post(duplicateApi)
+            mockMvc.perform(post(sendAuthCodeApi)
                             .with(user("user").roles("USER"))
                             .with(csrf())
                             .contentType(MediaType.APPLICATION_JSON)
@@ -95,7 +93,7 @@ public class AuthControllerTest extends ControllerTest {
                             preprocessResponse(prettyPrint()),
                             requestFields(
                                     fieldWithPath("email").type(JsonFieldType.STRING)
-                                            .description("중복 검사 대상 이메일")
+                                            .description("인증 코드를 받을 이메일")
                             ),
                             responseFields(
                                     fieldWithPath("timestamp").type(JsonFieldType.STRING)
@@ -108,14 +106,14 @@ public class AuthControllerTest extends ControllerTest {
 
         @DisplayName("이메일이 유효한 형태가 아닌 경우")
         @NullAndEmptySource
-        @ValueSource(strings = {"test@","test@kumoh","test@k&um","test@kumoh.123","@kumoh.ac.kr"})
+        @ValueSource(strings = {"test@","test@kumoh","test@k&um","test@kumoh.123","test@naver.com"})
         @ParameterizedTest
         void failIfEmailIsNotValid(String email) throws Exception {
             // given
             ValidateEmailRequest request = new ValidateEmailRequest(email);
 
             // when -> then
-            mockMvc.perform(post(duplicateApi)
+            mockMvc.perform(post(sendAuthCodeApi)
                             .with(user("user").roles("USER"))
                             .with(csrf())
                             .contentType(MediaType.APPLICATION_JSON)
@@ -146,12 +144,13 @@ public class AuthControllerTest extends ControllerTest {
         JoinRequest joinRequest = new JoinRequest(
                 "김건우",
                 "test12345@kumoh.ac.kr",
+                "123456",
                 "test12345",
                 Track.BACK,
                 "컴퓨터공학과"
         );
 
-        @DisplayName("요청 정보가 모두 유효하면 회원가입에 성공")
+        @DisplayName("요청 정보가 모두 유효하고 인증코드가 일치하면 회원가입에 성공")
         @Test
         void signupSuccess() throws Exception {
             // when -> then
@@ -169,6 +168,7 @@ public class AuthControllerTest extends ControllerTest {
                             requestFields(
                                     fieldWithPath("name").type(JsonFieldType.STRING).description("이름"),
                                     fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
+                                    fieldWithPath("authCode").type(JsonFieldType.STRING).description("인증코드"),
                                     fieldWithPath("password").type(JsonFieldType.STRING).description("비밀번호"),
                                     fieldWithPath("track").type(JsonFieldType.STRING).description("트랙"),
                                     fieldWithPath("major").type(JsonFieldType.STRING).description("전공")
@@ -183,6 +183,7 @@ public class AuthControllerTest extends ControllerTest {
             JoinRequest invalidJoinRequest = new JoinRequest(
                     "",
                     "test12345@kumoh.ac.kr",
+                    "",
                     "test12345",
                     Track.BACK,
                     ""
@@ -204,6 +205,7 @@ public class AuthControllerTest extends ControllerTest {
                             requestFields(
                                     fieldWithPath("name").type(JsonFieldType.STRING).description("이름"),
                                     fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
+                                    fieldWithPath("authCode").type(JsonFieldType.STRING).description("인증코드"),
                                     fieldWithPath("password").type(JsonFieldType.STRING).description("비밀번호"),
                                     fieldWithPath("track").type(JsonFieldType.STRING).description("트랙"),
                                     fieldWithPath("major").type(JsonFieldType.STRING).description("전공")
@@ -224,6 +226,7 @@ public class AuthControllerTest extends ControllerTest {
             JoinRequest invalidJoinRequest = new JoinRequest(
                     "김건우",
                     "test12345@kumoh.ac.kr",
+                    "123456",
                     "test",
                     Track.BACK,
                     "컴퓨터공학과"
@@ -245,6 +248,7 @@ public class AuthControllerTest extends ControllerTest {
                             requestFields(
                                     fieldWithPath("name").type(JsonFieldType.STRING).description("이름"),
                                     fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
+                                    fieldWithPath("authCode").type(JsonFieldType.STRING).description("인증코드"),
                                     fieldWithPath("password").type(JsonFieldType.STRING).description("비밀번호"),
                                     fieldWithPath("track").type(JsonFieldType.STRING).description("트랙"),
                                     fieldWithPath("major").type(JsonFieldType.STRING).description("전공")
@@ -265,6 +269,7 @@ public class AuthControllerTest extends ControllerTest {
             Map<String, String> input = new HashMap<>();
             input.put("name", "김건우");
             input.put("email", "test12345@kumoh.ac.kr");
+            input.put("authCode", "123456");
             input.put("password", "test12345");
             input.put("track", "FULLSTACK");
             input.put("major", "컴퓨터공학과");
@@ -286,6 +291,7 @@ public class AuthControllerTest extends ControllerTest {
                             requestFields(
                                     fieldWithPath("name").type(JsonFieldType.STRING).description("이름"),
                                     fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
+                                    fieldWithPath("authCode").type(JsonFieldType.STRING).description("인증코드"),
                                     fieldWithPath("password").type(JsonFieldType.STRING).description("비밀번호"),
                                     fieldWithPath("track").type(JsonFieldType.STRING).description("트랙"),
                                     fieldWithPath("major").type(JsonFieldType.STRING).description("전공")
@@ -322,6 +328,44 @@ public class AuthControllerTest extends ControllerTest {
                             requestFields(
                                     fieldWithPath("name").type(JsonFieldType.STRING).description("이름"),
                                     fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
+                                    fieldWithPath("authCode").type(JsonFieldType.STRING).description("인증코드"),
+                                    fieldWithPath("password").type(JsonFieldType.STRING).description("비밀번호"),
+                                    fieldWithPath("track").type(JsonFieldType.STRING).description("트랙"),
+                                    fieldWithPath("major").type(JsonFieldType.STRING).description("전공")
+                            ),
+                            responseFields(
+                                    fieldWithPath("timestamp").type(JsonFieldType.STRING)
+                                            .description("응답 시간"),
+                                    fieldWithPath("message").type(JsonFieldType.STRING)
+                                            .description("응답 메시지")
+                            )
+                    ));
+        }
+
+        @DisplayName("인증코드 불일치 시 가입 실패")
+        @Test
+        void signupFailIfAuthCodeIsNotCorrect() throws Exception {
+            // given
+            doThrow(new ServiceException(ErrorCode.MISMATCH_EMAIL_AUTH_CODE)).when(authService).join(any(JoinRequest.class));
+
+            // when -> then
+            mockMvc.perform(post(signupApiPath)
+                            .with(user("user").roles("USER"))
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(joinRequest))
+                    )
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(result -> assertThat(result.getResolvedException()).isInstanceOf(ServiceException.class))
+                    .andDo(document(
+                            "auth/auth-signup-fail-authCode-is-not-correct",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            requestFields(
+                                    fieldWithPath("name").type(JsonFieldType.STRING).description("이름"),
+                                    fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
+                                    fieldWithPath("authCode").type(JsonFieldType.STRING).description("인증코드"),
                                     fieldWithPath("password").type(JsonFieldType.STRING).description("비밀번호"),
                                     fieldWithPath("track").type(JsonFieldType.STRING).description("트랙"),
                                     fieldWithPath("major").type(JsonFieldType.STRING).description("전공")


### PR DESCRIPTION
### 🌱 작업 사항 
- 이메일 인증 기능 추가
  - 우리 학교 이메일만 가능하게 변경
- 이메일 인증 기능 테스트

### ❓ 리뷰 포인트
- 메일과 인증코드를 Redis에 저장하고, 만료 시간을 3분으로 설정했습니다.
- 인증코드는 무작위 6자리로 설정
- 현재는 제 메일로 보내는 것으로 설정
  - likelion.org 메일로 설정하면 US에서 보내는 것으로 되어 학교 이메일에서 스팸 메시지로 처리하는 문제

### 🦄 관련 이슈
resolves #14 